### PR TITLE
remove package dependcy on pyforge and unittest2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,8 @@
 import os
-import platform
-import itertools
 from setuptools import setup, find_packages
 
 with open(os.path.join(os.path.dirname(__file__), "waiting", "__version__.py")) as version_file:
     exec(version_file.read())
-
-_INSTALL_REQUIREMENTS = ["pyforge"]
-if platform.python_version() < '2.7':
-    _INSTALL_REQUIREMENTS.append('unittest2')
 
 setup(name="waiting",
       classifiers = [
@@ -24,7 +18,8 @@ setup(name="waiting",
       author_email="vmalloc@gmail.com",
       version=__version__,
       packages=find_packages(exclude=["tests"]),
-      install_requires=_INSTALL_REQUIREMENTS,
+      install_requires=[],
+      tests_require=["pyforge"],
       scripts=[],
       namespace_packages=[]
       )


### PR DESCRIPTION
unittest2 is not used as far as I can see
pyforge is only required for tests, not for installation